### PR TITLE
Add contraption nav and analytics

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5,7 +5,7 @@ body {
     line-height: 1.6;
 }
 
-#content {
+#feed {
     max-width: 800px;
     margin: 2rem auto;
     padding: 0 1rem;
@@ -17,4 +17,24 @@ body {
     border-radius: 6px;
     font-style: italic;
     margin-bottom: 4rem;
+}
+
+.contraption-nav {
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+    font-family: monospace;
+    margin: 1rem 0;
+    padding: 0.5rem;
+}
+
+.contraption-nav a {
+    color: #c41c1c;
+    text-decoration: none;
+    border-bottom: 1px dashed transparent;
+    padding: 0.25rem 0.5rem;
+}
+
+.contraption-nav a:hover {
+    border-bottom-color: #999;
 }

--- a/index.html
+++ b/index.html
@@ -4,15 +4,26 @@
     <meta charset="UTF-8">
     <title>Edgar Davtyan</title>
     <link rel="stylesheet" href="css/style.css">
+    <!-- Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-1234567890"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-1234567890');
+    </script>
 </head>
 <body>
-    <nav>
+    <nav class="contraption-nav">
+        <a href="#feed">Feed</a>
         <a href="#now">Now</a>
+        <a href="#contact">Contact</a>
     </nav>
-    <div id="content"></div>
+    <div id="feed"></div>
     <section id="now" class="now">
         <p>Currently exploring new data science projects and refining my skills.</p>
     </section>
+    <script src="js/utils.js"></script>
     <script type="module" src="js/render.js"></script>
 </body>
 </html>

--- a/js/render.js
+++ b/js/render.js
@@ -3,7 +3,7 @@ import { fetchData, parseMarkdown, incrementLike, getLikes, incrementView, getVi
 function renderPage() {
     fetchData('data/data.json')
         .then(data => {
-            const container = document.getElementById('content');
+            const container = document.getElementById('feed');
             container.innerHTML = `<h1>${data.title}</h1><p>${data.message}</p>`;
         })
         .catch(err => {
@@ -13,7 +13,7 @@ function renderPage() {
 
 function renderPost(post) {
     incrementView(post.id);
-    const container = document.getElementById('content');
+    const container = document.getElementById('feed');
 
     const postDiv = document.createElement('div');
     postDiv.className = 'post';


### PR DESCRIPTION
## Summary
- implement new contraption navigation bar
- swap feed container id and update script
- include GA4 snippet in page head
- load utils.js separately

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6856a2e6fe208332a90edde43b5d23bd